### PR TITLE
Fix 'can't infer block return type'

### DIFF
--- a/src/cru/area.cr
+++ b/src/cru/area.cr
@@ -3,23 +3,23 @@ require "./control"
 module Cru
   abstract class Area < Control
     @@on_draw_cb = Proc(UI::AreaHandler*, UI::Area*, UI::AreaDrawParams*, Nil).new { |h, a, p|
-      h.value.data.as(Area*).value.on_draw(p.value)
+      h.value.data.as(Area*).value.on_draw(p.value).as(Nil)
     }
 
     @@on_mouse_event_cb = Proc(UI::AreaHandler*, UI::Area*, UI::AreaMouseEvent*, Nil).new { |h, a, e|
-      h.value.data.as(Area*).value.on_mouse_event(e.value)
+      h.value.data.as(Area*).value.on_mouse_event(e.value).as(Nil)
     }
 
     @@on_mouse_crossed_cb = Proc(UI::AreaHandler*, UI::Area*, LibC::Int, Nil).new { |h, a, l|
-      h.value.data.as(Area*).value.on_mouse_crossed(l.to_i > 0)
+      h.value.data.as(Area*).value.on_mouse_crossed(l.to_i > 0).as(Nil)
     }
 
     @@on_drag_broken_cb = Proc(UI::AreaHandler*, UI::Area*, Nil).new { |h, a|
-      h.value.data.as(Area*).value.on_drag_broken
+      h.value.data.as(Area*).value.on_drag_broken.as(Nil)
     }
 
     @@on_key_event_cb = Proc(UI::AreaHandler*, UI::Area*, UI::AreaKeyEvent*, Nil).new { |h, a, e|
-      h.value.data.as(Area*).value.on_key_event(e.value)
+      h.value.data.as(Area*).value.on_key_event(e.value).as(Nil)
     }
 
     def initialize(width = nil, height = width)


### PR DESCRIPTION
Original error message (Crystal 1.4.1): 
```
In lib/cru/src/cru/area.cr:5:80

 5 | @@on_draw_cb = Proc(UI::AreaHandler*, UI::Area*, UI::AreaDrawParams*, Nil).new { |h, a, p|
                                                                                ^--
Error: can't infer block return type, try to cast the block body with `as`. See: https://crystal-lang.org/reference/syntax_and_semantics/as.html#usage-for-when-the-compiler-cant-infer-the-type-of-a-block
```